### PR TITLE
Update Cordova Add Swift Support Plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ wifi.getHostname(function success(hostname){
 Returns this device's network info. Android only.
 
 ```javascript
-wifi.getHostname(function success(info){
+wifi.getInfo(function success(info){
     console.log(info); //
     /*
     {

--- a/plugin.xml
+++ b/plugin.xml
@@ -40,8 +40,8 @@
         <source-file src="src/ios/WifiInfo.swift"/>
         <header-file src="src/ios/Hostname.h"/>
         <source-file src="src/ios/Hostname.m"/>
-        <dependency id="cordova-plugin-add-swift-support" version="1.7.0"/>
 
     </platform>
+        <dependency id="cordova-plugin-add-swift-support" version="1.7.1"/>
 
 </plugin>

--- a/plugin.xml
+++ b/plugin.xml
@@ -40,7 +40,8 @@
         <source-file src="src/ios/WifiInfo.swift"/>
         <header-file src="src/ios/Hostname.h"/>
         <source-file src="src/ios/Hostname.m"/>
+            <dependency id="cordova-plugin-add-swift-support" version="1.7.0"/>
+
     </platform>
 
-    <dependency id="cordova-plugin-add-swift-support" version="1.7.0"/>
 </plugin>

--- a/plugin.xml
+++ b/plugin.xml
@@ -40,7 +40,7 @@
         <source-file src="src/ios/WifiInfo.swift"/>
         <header-file src="src/ios/Hostname.h"/>
         <source-file src="src/ios/Hostname.m"/>
-            <dependency id="cordova-plugin-add-swift-support" version="1.7.0"/>
+        <dependency id="cordova-plugin-add-swift-support" version="1.7.0"/>
 
     </platform>
 


### PR DESCRIPTION
Dear Awesome Developer Eric ,

It seem like cordova-plugin-add-swift-support 1.7.0 break cordova-android 7.0 build. After Increment Version number to cordova-plugin-add-swift-support 1.7.1 . it is working fine.

However , Due to I am not originate author of plugin nor I don't have any knowledge of how this plugin works. I submit a pull request for you to review.

Thank you, :+1: 

Juthawong Naisanguansee